### PR TITLE
Trying to fix auto-increment

### DIFF
--- a/src/main/java/com/vacdnd/tools/quicktest/Blorbo.java
+++ b/src/main/java/com/vacdnd/tools/quicktest/Blorbo.java
@@ -4,15 +4,18 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
 
 @Entity
 public class Blorbo {
+	@SequenceGenerator(name="defSequence", allocationSize=1)
 	@Id
-	@GeneratedValue(strategy=GenerationType.AUTO)
-	long id;
+	@GeneratedValue(strategy=GenerationType.SEQUENCE, 
+					generator = "defSequence")
+	private long id;
 	
 	String name;
-
+s
 	public long getId() {
 		return id;
 	}

--- a/src/main/java/com/vacdnd/tools/quicktest/Blorbo.java
+++ b/src/main/java/com/vacdnd/tools/quicktest/Blorbo.java
@@ -15,7 +15,7 @@ public class Blorbo {
 	private long id;
 	
 	String name;
-s
+
 	public long getId() {
 		return id;
 	}


### PR DESCRIPTION
Right now, it increments with 50 at a time, when the service was shut down (due to inactivity). Otherwise increments normally. Set allocationSize of the id generator to 1, hopefully that fixes it.